### PR TITLE
Compose preview まわりの依存の修正

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -60,6 +60,8 @@ dependencies {
     androidTestImplementation(libs.androidx.testExt.junit)
     androidTestImplementation(libs.androidx.test.espressoCore)
     androidTestImplementation(libs.androidx.compose.uiTestJUnit4)
+
+    debugImplementation(libs.androidx.compose.uiTooling)
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ androidx-core = "1.7.0"
 androidx-appcompat = "1.3.0"
 androidx-constraintlayout = "2.0.4"
 androidx-compose = "1.2.0-alpha08"
-androidx-activity = "1.6.0-alpha03"
+androidx-activity = "1.5.0-beta01"
 androidx-composeMaterial3 = "1.0.0-alpha10"
 
 junit = "4.13.2"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,6 +40,7 @@ androidx-constraintLayout = { module = "androidx.constraintlayout:constraintlayo
 androidx-compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "androidx-compose" }
 androidx-compose-ui = { module = "androidx.compose.ui:ui", version.ref = "androidx-compose" }
 androidx-compose-uiTooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "androidx-compose" }
+androidx-compose-uiToolingPreview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "androidx-compose" }
 androidx-compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "androidx-compose" }
 androidx-compose-material = { module = "androidx.compose.material:material", version.ref = "androidx-compose" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
@@ -54,7 +55,7 @@ androidx-compose-uiTestJUnit4 = { module = "androidx.compose.ui:ui-test-junit4",
 androidx-compose = [
     "androidx-compose-compiler",
     "androidx-compose-ui",
-    "androidx-compose-uiTooling",
+    "androidx-compose-uiToolingPreview",
     "androidx-compose-foundation",
     "androidx-compose-material",
     "androidx-activity-compose",


### PR DESCRIPTION
## 概要
<!-- 何を実装したか・なぜ実装したか・関連 Issue -->
close #14 

preview が表示されない問題があったため

## 実装方法
<!-- どのように実装したか・ほかにどんな手法があり、なぜこれを選択したか -->
- androidx.activity 1.6.0-alpha01 はAndroid 13 DP2 SDK でのみコンパイルされるため、1.5.0-beta01 に変更した
  - https://developer.android.com/jetpack/androidx/releases/activity#1.6.0-alpha01
- また、ui-tooling モジュールが ui-tooling と ui-tooling-preview に分割されていたため、分割してui-tooling をdebugImplementation にした

## 影響範囲
<!-- どこまで確認すべきか -->
preview

## スクリーンショット/動画


## 備考・参考
