### PR TITLE
ksp で不備があればエラーを吐くよう更新

### DIFF
--- a/listsealed/src/main/java/io/github/warahiko/listsealed/ListSealedProcessor.kt
+++ b/listsealed/src/main/java/io/github/warahiko/listsealed/ListSealedProcessor.kt
@@ -54,10 +54,17 @@ class ListSealedProcessor(
                 package $packageName
 
                 val $qualifiedClassName.Companion.objects: List<$qualifiedClassName>
-                    get() = listOf(
                     """.trimIndent()
                 )
-                classDeclaration.getSealedSubclasses()
+
+                val sealedSubclasses = classDeclaration.getSealedSubclasses()
+                if (sealedSubclasses.none()) {
+                    appendLine("${indent}get() = emptyList()")
+                    return@buildString
+                }
+
+                appendLine("${indent}get() = listOf(")
+                sealedSubclasses
                     .filter { it.classKind == ClassKind.OBJECT }
                     .forEach { subclass ->
                         val qualifiedSubclassName = subclass.qualifiedName?.asString() ?: return@forEach

--- a/listsealed/src/main/java/io/github/warahiko/listsealed/ListSealedProcessor.kt
+++ b/listsealed/src/main/java/io/github/warahiko/listsealed/ListSealedProcessor.kt
@@ -24,22 +24,19 @@ class ListSealedProcessor(
         val (processable, next) = symbols.partition { it.validate() }
 
         processable.forEach { symbol ->
-            if (symbol.isSealed()) {
-                generateList(symbol)
-            } else {
-                val className = (symbol.qualifiedName ?: symbol.simpleName).asString()
-                logger.warn(
+            val className = (symbol.qualifiedName ?: symbol.simpleName).asString()
+            if (Modifier.SEALED !in symbol.modifiers) {
+                logger.error(
                     "Class $className is not a sealed class/interface.",
                     symbol = symbol,
                 )
+                return@forEach
             }
+
+            generateList(symbol)
         }
 
         return next
-    }
-
-    private fun KSClassDeclaration.isSealed(): Boolean {
-        return Modifier.SEALED in modifiers
     }
 
     private fun generateList(classDeclaration: KSClassDeclaration) {

--- a/listsealed/src/main/java/io/github/warahiko/listsealed/ListSealedProcessor.kt
+++ b/listsealed/src/main/java/io/github/warahiko/listsealed/ListSealedProcessor.kt
@@ -32,6 +32,13 @@ class ListSealedProcessor(
                 )
                 return@forEach
             }
+            if (symbol.declarations.all { (it as? KSClassDeclaration)?.isCompanionObject != true }) {
+                logger.error(
+                    "Class $className does not have a companion object.",
+                    symbol = symbol,
+                )
+                return@forEach
+            }
 
             generateList(symbol)
         }


### PR DESCRIPTION
## 概要
<!-- 何を実装したか・なぜ実装したか・関連 Issue -->
close #21 

- sealed サブクラスをリスト化する際に、アノテーションがついたクラスがsealed でなかったり、companion object がなければエラーを返すようにした
- ついでにサブクラスがなければemptyList を返すようにした

## 実装方法
<!-- どのように実装したか・ほかにどんな手法があり、なぜこれを選択したか -->
- Processor の修正

## 影響範囲
<!-- どこまで確認すべきか -->
自動生成ファイル

## スクリーンショット/動画


## 備考・参考
