### PR TITLE
tuner 画面実装

### DIFF
--- a/app/src/main/java/io/github/warahiko/mus/ui/component/MusMainTopBar.kt
+++ b/app/src/main/java/io/github/warahiko/mus/ui/component/MusMainTopBar.kt
@@ -1,9 +1,13 @@
 package io.github.warahiko.mus.ui.component
 
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import io.github.warahiko.mus.R
 import io.github.warahiko.mus.ui.theme.MusAppTheme
@@ -12,6 +16,7 @@ import io.github.warahiko.mus.ui.util.PreviewThemes
 @Composable
 fun MusMainTopBar(
     modifier: Modifier = Modifier,
+    actions: @Composable RowScope.() -> Unit = {},
 ) {
     CenterAlignedTopAppBar(
         title = {
@@ -19,6 +24,7 @@ fun MusMainTopBar(
                 text = stringResource(id = R.string.app_name),
             )
         },
+        actions = actions,
         modifier = modifier,
     )
 }
@@ -27,6 +33,13 @@ fun MusMainTopBar(
 @Composable
 private fun MusMainTopBarPreview() {
     MusAppTheme {
-        MusMainTopBar()
+        MusMainTopBar(actions = {
+            IconButton(onClick = {}) {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_play),
+                    contentDescription = null,
+                )
+            }
+        })
     }
 }

--- a/app/src/main/java/io/github/warahiko/mus/ui/tuner/TunerMeter.kt
+++ b/app/src/main/java/io/github/warahiko/mus/ui/tuner/TunerMeter.kt
@@ -25,7 +25,7 @@ import kotlin.math.sin
 
 @Composable
 fun TunerMeter(
-    value: Float,
+    valueProvider: () -> Float,
     modifier: Modifier = Modifier,
     backgroundColor: Color = MaterialTheme.colorScheme.surfaceVariant,
     tickColor: Color = MaterialTheme.colorScheme.onBackground,
@@ -118,7 +118,7 @@ fun TunerMeter(
                 radius = centerCircleRadius,
             )
 
-            val radian = -(PI * (60f - value) / 120f).toFloat()
+            val radian = -(PI * (60f - valueProvider()) / 120f).toFloat()
             drawLine(
                 color = indicatorColor,
                 start = center,
@@ -133,6 +133,6 @@ fun TunerMeter(
 @Composable
 fun TunerMeterPreview() {
     MusAppTheme {
-        TunerMeter(value = 21f)
+        TunerMeter(valueProvider = { 21f })
     }
 }

--- a/app/src/main/java/io/github/warahiko/mus/ui/tuner/TunerMeter.kt
+++ b/app/src/main/java/io/github/warahiko/mus/ui/tuner/TunerMeter.kt
@@ -1,0 +1,138 @@
+package io.github.warahiko.mus.ui.tuner
+
+import android.graphics.Rect
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.graphics.drawscope.withTransform
+import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.dp
+import io.github.warahiko.mus.ui.theme.MusAppTheme
+import io.github.warahiko.mus.ui.util.PreviewThemes
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.sin
+
+@Composable
+fun TunerMeter(
+    value: Float,
+    modifier: Modifier = Modifier,
+    backgroundColor: Color = MaterialTheme.colorScheme.surfaceVariant,
+    tickColor: Color = MaterialTheme.colorScheme.onBackground,
+    indicatorColor: Color = MaterialTheme.colorScheme.primary,
+) {
+    BoxWithConstraints(modifier = modifier) {
+        val centerCircleRadiusDp = 8.dp
+        val textSizeDp = 8.dp
+        val textMarginDp = 2.dp
+        val longLineLengthDp = 8.dp
+        val shortLineLengthDp = 6.dp
+
+        val radiusDp = maxWidth / 2 - longLineLengthDp
+        val centerDp = DpOffset(x = maxWidth / 2, y = textSizeDp + textMarginDp + longLineLengthDp / 2 + radiusDp)
+
+        Canvas(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(centerDp.y + centerCircleRadiusDp / 2),
+        ) {
+            val textPaint = Paint().asFrameworkPaint().also { paint ->
+                paint.isAntiAlias = true
+                paint.textSize = textSizeDp.toPx()
+            }
+
+            val centerCircleRadius = centerCircleRadiusDp.toPx()
+            val textMargin = textMarginDp.toPx()
+            val longLineLength = longLineLengthDp.toPx()
+            val shortLineLength = shortLineLengthDp.toPx()
+            val center = Offset(x = centerDp.x.toPx(), y = centerDp.y.toPx())
+            val radius = radiusDp.toPx()
+
+            val longLineInner = radius - longLineLength / 2
+            val longLineOuter = radius + longLineLength / 2
+
+            val shortLineInner = radius - shortLineLength / 2
+            val shortLineOuter = radius + shortLineLength / 2
+
+            drawArc(
+                color = backgroundColor,
+                topLeft = center - Offset(radius, radius),
+                size = Size(width = 2 * radius, height = 2 * radius),
+                startAngle = 187.5f,
+                sweepAngle = 165f,
+                useCenter = true,
+            )
+            repeat(11) {
+                val radian = -(2 * PI * ((1 + it) / 24f)).toFloat()
+                val cosR = cos(radian)
+                val sinR = sin(radian)
+                drawLine(
+                    color = tickColor,
+                    start = center + Offset(x = longLineInner * cosR, y = longLineInner * sinR),
+                    end = center + Offset(x = longLineOuter * cosR, y = longLineOuter * sinR),
+                    strokeWidth = 4f,
+                )
+                withTransform({
+                    rotate(degrees = (it - 5) * -15f, pivot = center)
+                }) {
+                    drawIntoCanvas { canvas ->
+                        val bottomCenter = center + Offset(x = 0f, y = -(longLineOuter + textMargin))
+                        val text = ((it - 5) * -10).toString()
+
+                        val bounds = Rect()
+                        textPaint.getTextBounds(text, 0, text.length, bounds)
+                        canvas.nativeCanvas.drawText(
+                            text,
+                            bottomCenter.x - bounds.width() / 2f,
+                            bottomCenter.y,
+                            textPaint,
+                        )
+                    }
+                }
+            }
+            repeat(10) {
+                val radian = -(2 * PI * ((1.5f + it) / 24f)).toFloat()
+                val cosR = cos(radian)
+                val sinR = sin(radian)
+                drawLine(
+                    color = tickColor,
+                    start = center + Offset(x = shortLineInner * cosR, y = shortLineInner * sinR),
+                    end = center + Offset(x = shortLineOuter * cosR, y = shortLineOuter * sinR),
+                    strokeWidth = 1f,
+                )
+            }
+
+            drawCircle(
+                color = indicatorColor,
+                center = center,
+                radius = centerCircleRadius,
+            )
+
+            val radian = -(PI * (60f - value) / 120f).toFloat()
+            drawLine(
+                color = indicatorColor,
+                start = center,
+                end = center + Offset(x = longLineInner * cos(radian), y = longLineInner * sin(radian)),
+                strokeWidth = 8f,
+            )
+        }
+    }
+}
+
+@PreviewThemes
+@Composable
+fun TunerMeterPreview() {
+    MusAppTheme {
+        TunerMeter(value = 21f)
+    }
+}

--- a/app/src/main/java/io/github/warahiko/mus/ui/tuner/TunerScreen.kt
+++ b/app/src/main/java/io/github/warahiko/mus/ui/tuner/TunerScreen.kt
@@ -67,7 +67,7 @@ fun TunerScreen(
                 )
             }
             TunerMeter(
-                value = 21f,
+                valueProvider = { 21f },
                 modifier = Modifier.fillMaxWidth(),
             )
             Row(

--- a/app/src/main/java/io/github/warahiko/mus/ui/tuner/TunerScreen.kt
+++ b/app/src/main/java/io/github/warahiko/mus/ui/tuner/TunerScreen.kt
@@ -1,17 +1,27 @@
 package io.github.warahiko.mus.ui.tuner
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import io.github.warahiko.mus.R
 import io.github.warahiko.mus.ui.component.MusMainTopBar
 import io.github.warahiko.mus.ui.theme.MusAppTheme
@@ -40,13 +50,43 @@ fun TunerScreen(
         Column(
             modifier = Modifier
                 .padding(contentPadding)
+                .padding(horizontal = 20.dp)
+                .padding(top = 12.dp, bottom = 24.dp)
                 .fillMaxSize(),
-            verticalArrangement = Arrangement.Center,
-            horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Text(
-                text = "Tuner",
+                text = stringResource(id = R.string.tuner_a4_frequency, 442),
+                style = MaterialTheme.typography.headlineSmall,
+                modifier = Modifier.fillMaxWidth(),
             )
+            Spacer(modifier = Modifier.height(60.dp))
+            Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                Text(
+                    text = stringResource(id = R.string.tuner_cent, "+21"),
+                    style = MaterialTheme.typography.headlineLarge,
+                )
+            }
+            TunerMeter(
+                value = 21f,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.Center,
+                verticalAlignment = Alignment.Bottom,
+            ) {
+                Text(
+                    text = "C#",
+                    fontSize = 128.sp,
+                    fontWeight = FontWeight.Bold,
+                    style = MaterialTheme.typography.displayLarge,
+                )
+                Text(
+                    text = "4",
+                    fontWeight = FontWeight.Bold,
+                    style = MaterialTheme.typography.displayMedium,
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/io/github/warahiko/mus/ui/tuner/TunerScreen.kt
+++ b/app/src/main/java/io/github/warahiko/mus/ui/tuner/TunerScreen.kt
@@ -4,12 +4,15 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import io.github.warahiko.mus.R
 import io.github.warahiko.mus.ui.component.MusMainTopBar
 import io.github.warahiko.mus.ui.theme.MusAppTheme
 import io.github.warahiko.mus.ui.util.PreviewThemes
@@ -22,7 +25,16 @@ fun TunerScreen(
     Scaffold(
         modifier = modifier,
         topBar = {
-            MusMainTopBar()
+            MusMainTopBar(
+                actions = {
+                    IconButton(onClick = onClickGoToOscillator) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_play),
+                            contentDescription = null,
+                        )
+                    }
+                }
+            )
         }
     ) { contentPadding ->
         Column(
@@ -35,9 +47,6 @@ fun TunerScreen(
             Text(
                 text = "Tuner",
             )
-            Button(onClick = onClickGoToOscillator) {
-                Text(text = "Go to Oscillator")
-            }
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,5 +4,8 @@
     <string name="tuner_label">チューナー</string>
     <string name="setting_label">設定</string>
 
+    <string name="tuner_a4_frequency">A4 = %d Hz</string>
+    <string name="tuner_cent">%s¢</string>
+
     <string name="oscillator_title">再生</string>
 </resources>


### PR DESCRIPTION
## 概要
<!-- 何を実装したか・なぜ実装したか・関連 Issue -->
close #30 

## 実装方法
<!-- どのように実装したか・ほかにどんな手法があり、なぜこれを選択したか -->
- Canvas

## 影響範囲
<!-- どこまで確認すべきか -->
tuner 画面

## スクリーンショット/動画

<img src=https://user-images.githubusercontent.com/23146955/169044902-36fe9664-21d8-4749-9a94-7c81797d5b50.png  width=200px>



## 備考・参考
recomposition を減らすため、値をラムダで渡す
- https://developer.android.com/jetpack/compose/performance#defer-reads
- https://developer.android.com/jetpack/compose/phases#phased-state-reads